### PR TITLE
Add Google Finance Chrome extension

### DIFF
--- a/packages/google_finance_extension/README.md
+++ b/packages/google_finance_extension/README.md
@@ -1,0 +1,39 @@
+# Google Finance Quick View
+
+A Chrome extension that provides a compact Google Finance experience inside the toolbar popup. Look up tickers, review the latest price action, and maintain a personal watchlist that syncs with your Chrome profile.
+
+## Features
+
+- 🔎 **Instant lookup** – Search for any instrument available on Google Finance. If you only provide the ticker symbol the extension automatically defaults to the NASDAQ exchange.
+- 📈 **Price & change** – Displays the last traded price together with the intraday change and percentage change.
+- 🧾 **Key stats** – Extracts commonly used metrics such as the day range, 52-week range, market cap, dividend yield, and P/E ratio whenever Google Finance exposes them on the instrument page.
+- ⭐ **Watchlist** – Save your favourite tickers and reload them with a single click. The list is stored via `chrome.storage.sync` (with a graceful fallback to `localStorage` during development).
+
+## Installation
+
+1. Clone or download this repository.
+2. Open **chrome://extensions** in Google Chrome.
+3. Enable **Developer mode** using the toggle in the top-right corner.
+4. Click **Load unpacked** and select the `packages/google_finance_extension` directory.
+5. The "Google Finance Quick View" icon will appear in your toolbar. Pin it for easier access.
+
+## Usage
+
+1. Click the extension icon to open the popup.
+2. Enter a ticker symbol. Examples:
+   - `GOOGL:NASDAQ`
+   - `MSFT:NASDAQ`
+   - `AAPL` (will automatically resolve to `AAPL:NASDAQ`)
+   - `EURUSD:CUR` for currency pairs
+3. Press **Lookup** or hit **Enter**.
+4. The popup will display the latest information fetched from the Google Finance product page.
+5. Use **Add** to store the current symbol in your watchlist, and tap a saved item to refresh the data later.
+
+> ⚠️ **Note:** Google Finance pages are primarily designed for human consumption and may change without notice. If Google adjusts their markup, the parsing selectors might need to be updated.
+
+## Development notes
+
+- The popup is written with vanilla HTML, CSS, and JavaScript to keep bundle size minimal.
+- Network requests target the public Google Finance website; no third-party data providers are involved.
+- When testing outside Chrome (for example, opening `popup.html` directly), watchlist persistence falls back to `localStorage` so that you can interact with the UI without extension privileges.
+- Consider adding icons under an `icons/` directory and referencing them from `manifest.json` if you intend to publish the extension to the Chrome Web Store.

--- a/packages/google_finance_extension/manifest.json
+++ b/packages/google_finance_extension/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "Google Finance Quick View",
+  "description": "Quickly inspect quotes from Google Finance without leaving your current tab.",
+  "version": "1.0.0",
+  "action": {
+    "default_title": "Google Finance Quick View",
+    "default_popup": "popup.html"
+  },
+  "permissions": [
+    "storage"
+  ],
+  "host_permissions": [
+    "https://www.google.com/finance/*"
+  ]
+}

--- a/packages/google_finance_extension/popup.html
+++ b/packages/google_finance_extension/popup.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Google Finance Quick View</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Google Finance</h1>
+      <p class="subtitle">Look up live market data directly from Google Finance.</p>
+    </header>
+
+    <main>
+      <form id="ticker-form">
+        <label for="ticker-input" class="sr-only">Ticker symbol</label>
+        <input
+          type="text"
+          id="ticker-input"
+          name="ticker"
+          placeholder="Enter symbol (e.g. GOOGL:NASDAQ)"
+          autocomplete="off"
+          required
+        />
+        <button type="submit" id="lookup-button">Lookup</button>
+      </form>
+
+      <section id="result" class="card hidden" aria-live="polite"></section>
+
+      <section class="card" id="watchlist">
+        <div class="card-header">
+          <h2>Watchlist</h2>
+          <button id="add-to-watchlist" class="secondary" disabled>Add</button>
+        </div>
+        <p class="hint">
+          Save frequently used tickers for quick access. Items are stored with your Chrome profile.
+        </p>
+        <ul id="watchlist-items"></ul>
+      </section>
+    </main>
+
+    <template id="watchlist-item-template">
+      <li>
+        <button class="watchlist-symbol" data-symbol=""></button>
+        <button class="remove" title="Remove from watchlist" aria-label="Remove">&times;</button>
+      </li>
+    </template>
+
+    <script src="popup.js" type="module"></script>
+  </body>
+</html>

--- a/packages/google_finance_extension/popup.js
+++ b/packages/google_finance_extension/popup.js
@@ -1,0 +1,413 @@
+const WATCHLIST_KEY = 'googleFinanceWatchlist';
+const DEFAULT_EXCHANGE = 'NASDAQ';
+const COMMON_EXCHANGES = new Set([
+  'AMS',
+  'ASX',
+  'BIT',
+  'BSE',
+  'CME',
+  'CURRENCY',
+  'CUR',
+  'EPA',
+  'ETR',
+  'FRA',
+  'HKG',
+  'INDEXDJX',
+  'INDEXNASDAQ',
+  'INDEXSP',
+  'JSE',
+  'KRX',
+  'LON',
+  'MCX',
+  'NASDAQ',
+  'NSE',
+  'NYSE',
+  'NYSEAMERICAN',
+  'NYSEARCA',
+  'NYSEMKT',
+  'OTCMKTS',
+  'SGX',
+  'SHA',
+  'SHE',
+  'SIX',
+  'TSE',
+  'TSX',
+  'TSXV'
+]);
+
+const form = document.getElementById('ticker-form');
+const input = document.getElementById('ticker-input');
+const resultContainer = document.getElementById('result');
+const watchlistContainer = document.getElementById('watchlist-items');
+const addToWatchlistButton = document.getElementById('add-to-watchlist');
+const watchlistItemTemplate = document.getElementById('watchlist-item-template');
+
+let currentQuote = null;
+let watchlist = [];
+
+const INTERESTING_LABELS = new Map([
+  ['52-week range', '52 Week Range'],
+  ['52 week range', '52 Week Range'],
+  ['day range', 'Day Range'],
+  ["day's range", 'Day Range'],
+  ['market cap', 'Market Cap'],
+  ['market capitalization', 'Market Cap'],
+  ['pe ratio', 'P/E Ratio'],
+  ['p/e ratio', 'P/E Ratio'],
+  ['dividend yield', 'Dividend Yield'],
+  ['prev close', 'Previous Close'],
+  ['previous close', 'Previous Close']
+]);
+
+const storageArea = typeof chrome !== 'undefined' && chrome.storage && chrome.storage.sync
+  ? chrome.storage.sync
+  : null;
+
+async function loadWatchlist() {
+  if (storageArea) {
+    const stored = await storageArea.get([WATCHLIST_KEY]);
+    return stored[WATCHLIST_KEY] ?? [];
+  }
+
+  try {
+    const raw = localStorage.getItem(WATCHLIST_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch (error) {
+    console.error('Unable to read watchlist from localStorage', error);
+    return [];
+  }
+}
+
+async function persistWatchlist(next) {
+  watchlist = next;
+  if (storageArea) {
+    await storageArea.set({ [WATCHLIST_KEY]: watchlist });
+    return;
+  }
+
+  try {
+    localStorage.setItem(WATCHLIST_KEY, JSON.stringify(watchlist));
+  } catch (error) {
+    console.error('Unable to persist watchlist in localStorage', error);
+  }
+}
+
+function normaliseSymbol(value) {
+  if (!value) {
+    return '';
+  }
+
+  const cleaned = value.trim().toUpperCase().replace(/\s+/g, '');
+  if (!cleaned) {
+    return '';
+  }
+
+  if (!cleaned.includes(':')) {
+    return `${cleaned}:${DEFAULT_EXCHANGE}`;
+  }
+
+  const [first, second] = cleaned.split(':', 2);
+  if (!second) {
+    return first;
+  }
+
+  const isFirstExchange = COMMON_EXCHANGES.has(first);
+  const isSecondExchange = COMMON_EXCHANGES.has(second);
+
+  if (isFirstExchange && !isSecondExchange) {
+    return `${second}:${first}`;
+  }
+
+  return `${first}:${second}`;
+}
+
+function buildQuoteUrl(symbol) {
+  const encoded = encodeURIComponent(symbol).replace(/%3A/g, ':');
+  return `https://www.google.com/finance/quote/${encoded}`;
+}
+
+function renderWatchlist() {
+  watchlistContainer.innerHTML = '';
+  if (!watchlist.length) {
+    const emptyState = document.createElement('li');
+    emptyState.textContent = 'No saved tickers yet.';
+    emptyState.className = 'empty';
+    watchlistContainer.appendChild(emptyState);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  watchlist.forEach((symbol) => {
+    const node = watchlistItemTemplate.content.firstElementChild.cloneNode(true);
+    const symbolButton = node.querySelector('.watchlist-symbol');
+    const removeButton = node.querySelector('.remove');
+
+    symbolButton.dataset.symbol = symbol;
+    symbolButton.textContent = symbol;
+    symbolButton.addEventListener('click', () => lookup(symbol));
+
+    removeButton.addEventListener('click', async () => {
+      const next = watchlist.filter((entry) => entry !== symbol);
+      await persistWatchlist(next);
+      renderWatchlist();
+      if (currentQuote?.symbol === symbol) {
+        addToWatchlistButton.disabled = false;
+      }
+    });
+
+    fragment.appendChild(node);
+  });
+
+  watchlistContainer.appendChild(fragment);
+}
+
+function setResultContent(content) {
+  resultContainer.innerHTML = '';
+  if (!content) {
+    resultContainer.classList.add('hidden');
+    return;
+  }
+
+  resultContainer.classList.remove('hidden');
+  resultContainer.appendChild(content);
+}
+
+function renderError(message) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'error';
+  wrapper.textContent = message;
+  setResultContent(wrapper);
+  currentQuote = null;
+  addToWatchlistButton.disabled = true;
+}
+
+function renderQuote(quote) {
+  const wrapper = document.createElement('div');
+
+  const heading = document.createElement('h2');
+  heading.textContent = quote.name ?? quote.symbol;
+  wrapper.appendChild(heading);
+
+  if (quote.tickerLabel) {
+    const ticker = document.createElement('div');
+    ticker.className = 'ticker';
+    ticker.textContent = quote.tickerLabel;
+    wrapper.appendChild(ticker);
+  }
+
+  const price = document.createElement('div');
+  price.className = 'price';
+  price.textContent = quote.priceText;
+  wrapper.appendChild(price);
+
+  const change = document.createElement('div');
+  change.className = 'change';
+  if (typeof quote.changeRaw === 'number') {
+    change.classList.add(quote.changeRaw >= 0 ? 'positive' : 'negative');
+  }
+  change.textContent = quote.changeText;
+  wrapper.appendChild(change);
+
+  if (quote.metadata?.length) {
+    const meta = document.createElement('div');
+    meta.className = 'metadata';
+    meta.textContent = quote.metadata.join(' \u2022 ');
+    wrapper.appendChild(meta);
+  }
+
+  if (quote.additionalRows?.length) {
+    const list = document.createElement('ul');
+    list.className = 'metadata-list';
+    quote.additionalRows.forEach((row) => {
+      const item = document.createElement('li');
+      item.textContent = `${row.label}: ${row.value}`;
+      list.appendChild(item);
+    });
+    wrapper.appendChild(list);
+  }
+
+  setResultContent(wrapper);
+  currentQuote = quote;
+  addToWatchlistButton.disabled = watchlist.includes(quote.symbol);
+}
+
+function parseChange(text) {
+  if (!text) {
+    return { changeText: 'Change unavailable' };
+  }
+
+  const normalized = text.replace(/\s+/g, ' ').replace(/\u2212/g, '-');
+  const match = normalized.match(/([+\-]?[0-9.,]+)\s*\(([^)]+)\)/);
+  if (!match) {
+    return { changeText: normalized };
+  }
+
+  const rawChange = parseFloat(match[1].replace(/,/g, ''));
+  return {
+    changeText: normalized,
+    changeRaw: Number.isFinite(rawChange) ? rawChange : undefined,
+    changePercentText: match[2]
+  };
+}
+
+function parseKeyValuePairs(doc) {
+  const rows = [];
+  const cells = Array.from(doc.querySelectorAll('div[data-attrid]'));
+  cells.forEach((cell) => {
+    const label = cell.getAttribute('data-attrid');
+    if (!label) {
+      return;
+    }
+
+    const friendlyLabel = INTERESTING_LABELS.get(label.toLowerCase());
+    if (!friendlyLabel) {
+      return;
+    }
+
+    let value = cell.textContent?.trim();
+    if (!value) {
+      return;
+    }
+
+    const normalizedLabel = label.toLowerCase();
+    if (value.toLowerCase().startsWith(normalizedLabel)) {
+      value = value.slice(label.length).trim();
+    }
+
+    rows.push({ label: friendlyLabel, value });
+  });
+  return rows;
+}
+
+function extractQuoteFromDocument(doc, symbol) {
+  const priceElement = doc.querySelector('.YMlKec.fxKbKc');
+  if (!priceElement) {
+    throw new Error('Unable to locate price on Google Finance. Try a fully qualified symbol such as GOOGL:NASDAQ.');
+  }
+
+  const nameElement = doc.querySelector('.zzDege');
+  const tickerElement = doc.querySelector('.P6K39c');
+  const changeElement =
+    doc.querySelector('[data-last-price-change]') ||
+    doc.querySelector('.NydbP.Vd') ||
+    doc.querySelector('.P2Luy.Ebnabc') ||
+    doc.querySelector('.WlRRw.IsqQVc.NprOob');
+
+  const metadataElement = doc.querySelector('.ygUjEc');
+
+  const quote = {
+    symbol,
+    name: nameElement?.textContent?.trim(),
+    tickerLabel: tickerElement?.textContent?.trim(),
+    priceText: priceElement.textContent.trim()
+  };
+
+  const changeData = parseChange(changeElement?.textContent?.trim());
+  quote.changeText = changeData.changeText;
+  quote.changeRaw = changeData.changeRaw;
+
+  const metadata = [];
+  if (metadataElement?.textContent) {
+    metadata.push(metadataElement.textContent.trim());
+  }
+  metadata.push(`Fetched ${new Date().toLocaleTimeString()}`);
+  quote.metadata = metadata;
+
+  const rows = parseKeyValuePairs(doc).filter((row) =>
+    ['52-week range', 'Day range', 'Market cap', 'P/E ratio', 'Dividend yield'].some((key) =>
+      row.label.toLowerCase().includes(key)
+    )
+  );
+  if (rows.length) {
+    quote.additionalRows = rows;
+  }
+
+  return quote;
+}
+
+async function fetchQuote(symbol) {
+  const url = buildQuoteUrl(symbol);
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123 Safari/537.36'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google Finance returned ${response.status}`);
+  }
+
+  const html = await response.text();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  return extractQuoteFromDocument(doc, symbol);
+}
+
+async function lookup(inputValue) {
+  const symbol = normaliseSymbol(inputValue);
+  if (!symbol) {
+    renderError('Enter a ticker symbol to begin.');
+    return;
+  }
+
+  input.value = symbol;
+  setResultContent(createLoadingSkeleton(symbol));
+
+  try {
+    const quote = await fetchQuote(symbol);
+    renderQuote(quote);
+  } catch (error) {
+    console.error(error);
+    renderError(error.message || 'Something went wrong while requesting data from Google Finance.');
+  }
+}
+
+function createLoadingSkeleton(symbol) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'metadata';
+  wrapper.textContent = `Fetching ${symbol} from Google Finance...`;
+  return wrapper;
+}
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  lookup(input.value);
+});
+
+addToWatchlistButton.addEventListener('click', async () => {
+  if (!currentQuote) {
+    return;
+  }
+
+  if (watchlist.includes(currentQuote.symbol)) {
+    return;
+  }
+
+  const next = [...watchlist, currentQuote.symbol].sort();
+  await persistWatchlist(next);
+  renderWatchlist();
+  addToWatchlistButton.disabled = true;
+});
+
+function attachWatchlistDelegates() {
+  watchlistContainer.addEventListener('keydown', (event) => {
+    if (event.target.matches('.watchlist-symbol') && (event.key === 'Enter' || event.key === ' ')) {
+      event.preventDefault();
+      const symbol = event.target.dataset.symbol;
+      lookup(symbol);
+    }
+  });
+}
+
+async function init() {
+  watchlist = await loadWatchlist();
+  renderWatchlist();
+  attachWatchlistDelegates();
+
+  const [first] = watchlist;
+  if (first) {
+    lookup(first);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/packages/google_finance_extension/styles.css
+++ b/packages/google_finance_extension/styles.css
@@ -1,0 +1,225 @@
+:root {
+  color-scheme: light dark;
+  --accent: #0b57d0;
+  --accent-contrast: #ffffff;
+  --background: #f7f9fc;
+  --card-background: #ffffff;
+  --border-color: rgba(0, 0, 0, 0.08);
+  --text-color: #1f1f1f;
+  --muted-text: #5f6368;
+  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 16px;
+  background: var(--background);
+  color: var(--text-color);
+  min-width: 320px;
+}
+
+header {
+  margin-bottom: 12px;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: var(--muted-text);
+}
+
+form {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+input[type='text'] {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+button {
+  border: none;
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  transition: background 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+button.secondary:hover:not(:disabled) {
+  background: rgba(11, 87, 208, 0.08);
+}
+
+button:hover:not(:disabled) {
+  background: #0a47ad;
+}
+
+.card {
+  background: var(--card-background);
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  padding: 12px;
+  margin-bottom: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.card.hidden {
+  display: none;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.hint {
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-size: 0.8rem;
+  color: var(--muted-text);
+}
+
+#result h2 {
+  margin: 0 0 8px;
+  font-size: 1.1rem;
+}
+
+#result .price {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 4px 0;
+}
+
+#result .ticker {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted-text);
+  margin-bottom: 4px;
+}
+
+#result .change {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+#result .change.positive {
+  color: #0f9d58;
+}
+
+#result .change.negative {
+  color: #d93025;
+}
+
+#watchlist-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+#watchlist-items li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: rgba(11, 87, 208, 0.04);
+}
+
+#watchlist-items li.empty {
+  justify-content: center;
+  color: var(--muted-text);
+  font-style: italic;
+  border-style: dashed;
+  background: transparent;
+}
+
+.watchlist-symbol {
+  flex: 1;
+  background: transparent;
+  color: var(--accent);
+  font-size: 0.85rem;
+  border: none;
+  padding: 0;
+  text-align: left;
+}
+
+.remove {
+  background: transparent;
+  border: none;
+  font-size: 1rem;
+  color: var(--muted-text);
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+}
+
+.remove:hover {
+  color: #d93025;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.error {
+  color: #d93025;
+  font-weight: 600;
+}
+
+.metadata {
+  margin-top: 8px;
+  font-size: 0.8rem;
+  color: var(--muted-text);
+}
+
+.metadata-list {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  font-size: 0.8rem;
+  color: var(--muted-text);
+}
+
+.metadata-list li {
+  margin-bottom: 2px;
+}


### PR DESCRIPTION
## Summary
- add a standalone Google Finance toolbar extension with manifest, popup UI, and styling
- implement popup logic to fetch and parse quote data while maintaining a synced watchlist
- document installation, usage, and development considerations for the extension

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68cc92f41d24832e8646e5edc150d1ba